### PR TITLE
perf: skip git submodules during LSP startup file detection

### DIFF
--- a/src/lsp/start.ts
+++ b/src/lsp/start.ts
@@ -20,7 +20,8 @@ async function hasAnyFile(
           const gitPattern = pattern.replace('**/', ''); // Convert **/*.ts to *.ts for git
           
           // Use git ls-files to check if any tracked files match
-          const proc = Bun.spawn(['git', 'ls-files', gitPattern], {
+          // Skip submodules to avoid slow traversal in large repos
+          const proc = Bun.spawn(['git', 'ls-files', '--recurse-submodules=no', gitPattern], {
             cwd: directory,
             stdout: 'pipe',
             stderr: 'pipe'


### PR DESCRIPTION
## Summary

Optimizes LSP startup performance by adding the `--recurse-submodules=no` flag to git ls-files commands during language server detection. This prevents slow traversal of nested submodules in repositories that contain them, significantly improving startup times in large codebases with submodules.

## Changes

- Modified `hasAnyFile` function in `src/lsp/start.ts` to use `--recurse-submodules=no` flag with git ls-files
- Added explanatory comment documenting the performance optimization reasoning

## Impact

This change provides faster LSP startup times in repositories containing git submodules by avoiding unnecessary recursive traversal during the initial file pattern matching phase. The optimization maintains the same functionality while improving performance in affected repositories.

## Test Plan

- Verify LSP startup works correctly in repositories without submodules (no change in behavior)
- Test startup performance improvement in repositories with nested submodules
- Confirm that language server detection still works properly for all supported file types

🤖 Generated with [Claude Code](https://claude.ai/code)