### PR TITLE
fix: update test assertion for TypeScript strict mode description

### DIFF
--- a/tests/json/hover.test.ts
+++ b/tests/json/hover.test.ts
@@ -67,7 +67,7 @@ See more: https://www.typescriptlang.org/tsconfig#target`);
     const output = stripAnsi(result.stdout.toString());
     expect(output)
       .toBe(`Location: tests/fixtures/json/valid/tsconfig-with-schema.json:7:5
-Enable all strict type checking options.
+Enable all strict type-checking options.
 
 See more: https://www.typescriptlang.org/tsconfig#strict`);
   }, 10000);


### PR DESCRIPTION
## Summary

This PR fixes a failing test in the JSON hover functionality by updating the expected assertion text to match the current TypeScript JSON schema description.

**Key Changes:**
- Updated test assertion in `tests/json/hover.test.ts` to expect "strict type-checking" instead of "strict type checking"

## Background

The TypeScript JSON schema updated the description text for the `strict` compiler option from "Enable all strict type checking options." to "Enable all strict type-checking options." (added hyphen). This caused the hover test to fail as it was asserting against the old description.

## Testing

The test now passes with the updated assertion matching the current schema description from https://www.typescriptlang.org/tsconfig#strict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)